### PR TITLE
Task details

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ todoist tasks --filter "p1"        # High priority
 todoist tasks --filter "overdue"   # Overdue
 todoist tasks -p Work              # By project
 
+# Show task descriptions and comments
+todoist tasks -p Work --details
+
 # Add a task
 todoist add "Buy groceries"
 todoist add "Call mom" -d tomorrow

--- a/cmd/todoist/root.go
+++ b/cmd/todoist/root.go
@@ -26,7 +26,7 @@ func execute(args []string) error {
 		Version:       version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Default: show today's tasks
-			return runTasks(cmd, &flags, true, "", "")
+			return runTasks(cmd, &flags, true, "", "", false)
 		},
 	}
 	rootCmd.SetVersionTemplate("todoist {{.Version}}\n")

--- a/cmd/todoist/tasks.go
+++ b/cmd/todoist/tasks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -15,6 +16,7 @@ func newTasksCmd(flags *rootFlags) *cobra.Command {
 		project string
 		overdue bool
 		all     bool
+		details bool
 	)
 
 	cmd := &cobra.Command{
@@ -31,7 +33,7 @@ Examples:
   todoist tasks -p Work      # Tasks in Work project
   todoist tasks --overdue    # Shortcut for overdue filter`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTasks(cmd, flags, today, filter, project)
+			return runTasks(cmd, flags, today, filter, project, details)
 		},
 	}
 
@@ -40,11 +42,12 @@ Examples:
 	cmd.Flags().StringVarP(&project, "project", "p", "", "filter by project name")
 	cmd.Flags().BoolVar(&overdue, "overdue", false, "show only overdue tasks")
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "show all active tasks")
+	cmd.Flags().BoolVar(&details, "details", false, "show task descriptions and comments")
 
 	return cmd
 }
 
-func runTasks(cmd *cobra.Command, flags *rootFlags, today bool, filter, project string) error {
+func runTasks(cmd *cobra.Command, flags *rootFlags, today bool, filter, project string, details bool) error {
 	out := output.NewFormatter(os.Stdout, flags.asJSON)
 
 	client, err := getClient()
@@ -86,6 +89,41 @@ func runTasks(cmd *cobra.Command, flags *rootFlags, today bool, filter, project 
 	tasks, err := client.GetTasks(projectID, filter)
 	if err != nil {
 		return err
+	}
+
+	if !flags.asJSON && details {
+		if len(tasks) == 0 {
+			fmt.Fprintln(os.Stdout, "No tasks found.")
+			return nil
+		}
+
+		for i, t := range tasks {
+			fmt.Fprintln(os.Stdout, output.FormatTaskLine(&t))
+			if t.Description != "" {
+				fmt.Fprintf(os.Stdout, "    \033[90m%s\033[0m\n", t.Description)
+			}
+
+			comments, err := client.GetComments(t.ID, "")
+			if err != nil {
+				return err
+			}
+			if len(comments) > 0 {
+				fmt.Fprintf(os.Stdout, "    Comments (%d):\n", len(comments))
+				for _, c := range comments {
+					date := c.PostedAt
+					if len(date) >= 10 {
+						date = date[:10]
+					}
+					fmt.Fprintf(os.Stdout, "      [%s] %s\n", date, c.Content)
+				}
+			}
+
+			if i < len(tasks)-1 {
+				fmt.Fprintln(os.Stdout)
+			}
+		}
+
+		return nil
 	}
 
 	return out.WriteTasks(tasks)


### PR DESCRIPTION
## Summary
- Add `--details` flag to `todoist tasks` to show task descriptions and comments
- Keep JSON output unchanged; extra details only in human output
- Document the new flag in README

## Usage

```bash

todoist tasks -p "Work" --details

```
