### PR TITLE
Fix potential panics from date string slicing

### DIFF
--- a/cmd/todoist/auth.go
+++ b/cmd/todoist/auth.go
@@ -59,7 +59,8 @@ You can either:
 				return err
 			}
 
-			out.WriteSuccess(fmt.Sprintf("Authenticated successfully. Config saved to %s", config.ConfigPath()))
+			configPath, _ := config.ConfigPath() // Error already handled by Save()
+			out.WriteSuccess(fmt.Sprintf("Authenticated successfully. Config saved to %s", configPath))
 			return nil
 		},
 	}
@@ -70,7 +71,10 @@ You can either:
 		Short: "Remove stored credentials",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := output.NewFormatter(os.Stdout, flags.asJSON)
-			path := config.ConfigPath()
+			path, err := config.ConfigPath()
+			if err != nil {
+				return err
+			}
 			if err := os.Remove(path); err != nil {
 				if os.IsNotExist(err) {
 					out.WriteSuccess("No credentials stored.")

--- a/cmd/todoist/update.go
+++ b/cmd/todoist/update.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/buddyh/todoist-cli/internal/api"
 	"github.com/buddyh/todoist-cli/internal/output"
@@ -97,19 +96,4 @@ func newReopenCmd(flags *rootFlags) *cobra.Command {
 	}
 
 	return cmd
-}
-
-// Helper for comma-separated string to slice
-func splitLabels(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
-			result = append(result, t)
-		}
-	}
-	return result
 }

--- a/cmd/todoist/view.go
+++ b/cmd/todoist/view.go
@@ -58,7 +58,11 @@ func newViewCmd(flags *rootFlags) *cobra.Command {
 			if err == nil && len(comments) > 0 {
 				fmt.Printf("\nComments (%d):\n", len(comments))
 				for _, c := range comments {
-					fmt.Printf("  [%s] %s\n", c.PostedAt[:10], c.Content)
+					date := c.PostedAt
+					if len(date) >= 10 {
+						date = date[:10]
+					}
+					fmt.Printf("  [%s] %s\n", date, c.Content)
 				}
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,14 +18,21 @@ type Config struct {
 }
 
 // ConfigDir returns the config directory path
-func ConfigDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, configDirName)
+func ConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	return filepath.Join(home, configDirName), nil
 }
 
 // ConfigPath returns the full config file path
-func ConfigPath() string {
-	return filepath.Join(ConfigDir(), configFileName)
+func ConfigPath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFileName), nil
 }
 
 // Load loads the configuration from disk
@@ -36,7 +43,10 @@ func Load() (*Config, error) {
 	}
 
 	// Then try config file
-	path := ConfigPath()
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -59,7 +69,10 @@ func Load() (*Config, error) {
 
 // Save saves the configuration to disk
 func Save(cfg *Config) error {
-	dir := ConfigDir()
+	dir, err := ConfigDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config dir: %w", err)
 	}
@@ -69,7 +82,10 @@ func Save(cfg *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	path := ConfigPath()
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -313,7 +313,11 @@ func (f *Formatter) WriteCompletedTasks(resp *api.CompletedTasksResponse) error 
 	}
 
 	for _, t := range resp.Items {
-		fmt.Fprintf(f.w, "\033[90m%s\033[0m  \033[9m%s\033[0m\n", t.CompletedAt[:10], t.Content)
+		date := t.CompletedAt
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		fmt.Fprintf(f.w, "\033[90m%s\033[0m  \033[9m%s\033[0m\n", date, t.Content)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add bounds checks before slicing date strings to prevent panics
- Handle `os.UserHomeDir()` errors instead of silently ignoring them
- Remove unused `splitLabels()` function

## Changes

### Panic prevention (commit 1)
- `internal/output/format.go`: Add bounds check in `WriteCompletedTasks()` before slicing `CompletedAt`
- `cmd/todoist/view.go`: Add bounds check before slicing `PostedAt` in comment display

### Error handling improvement (commit 2)
- `internal/config/config.go`: `ConfigDir()` and `ConfigPath()` now return `(string, error)` instead of just `string`
- `cmd/todoist/auth.go`: Updated to handle new error returns from config functions

### Dead code removal (commit 2)
- `cmd/todoist/update.go`: Removed unused `splitLabels()` function and `strings` import

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)